### PR TITLE
Done the other alerts

### DIFF
--- a/face-react/src/components/TeacherHome.tsx
+++ b/face-react/src/components/TeacherHome.tsx
@@ -4,6 +4,7 @@ import Webcam from "react-webcam";
 import { currentUser, users } from "./LoginForm";
 import { useNavigate } from "react-router-dom";
 import { useEffect } from "react";
+import LogOut from "./alerts/LogOut";
 
 const TeacherHome = () => {
   const navigate = useNavigate();
@@ -18,7 +19,7 @@ const TeacherHome = () => {
   }
   return (
     <>
-      <button onClick={() => navigate("/")}>Log Out</button>
+      <LogOut handleLogout={() => navigate("/")} />
       <Grid templateColumns="repeat(5, 1fr)">
         {users.map(
           (user) =>

--- a/face-react/src/components/TeacherView.tsx
+++ b/face-react/src/components/TeacherView.tsx
@@ -5,6 +5,8 @@ import Webcam from "react-webcam";
 import { useNavigate } from "react-router-dom";
 
 import { currentUser } from "./LoginForm";
+import TerminateExam from "./alerts/TerminateExam";
+import LogOut from "./alerts/LogOut";
 
 // if (currentUser) {
 //   warnings = currentUser.warnings;
@@ -39,7 +41,7 @@ const TeacherView = () => {
   return (
     <>
       <div>
-        <button onClick={() => navigate("/")}>Log Out</button>
+        <LogOut handleLogout={() => navigate("/")} />
 
         <label>
           <Webcam />
@@ -62,10 +64,17 @@ const TeacherView = () => {
           Issue Warning
         </button>
       </div>
-      <div>
-        <button disabled={safe} onClick={() => alert("Are You sure?")}>
-          Terminate Exam
-        </button>
+      <div hidden={safe}>
+        <TerminateExam
+          handleTerminate={() =>
+            // add the logic here for stopping a webcam
+            {
+              if (currentUser !== undefined) {
+                currentUser.loggedIn = false;
+              }
+            }
+          }
+        />
       </div>
     </>
   );

--- a/face-react/src/components/alerts/EndExam.tsx
+++ b/face-react/src/components/alerts/EndExam.tsx
@@ -8,7 +8,7 @@ import {
   useDisclosure,
   Button,
 } from "@chakra-ui/react";
-import React, { useRef } from "react";
+import { useRef } from "react";
 
 interface Props {
   handleTerminate: () => void;
@@ -18,7 +18,6 @@ const EndExam = ({ handleTerminate }: Props) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const cancelRef = useRef(null);
 
-  // Create a new function to handle the "Yes" button click
   const handleConfirmTerminate = () => {
     handleTerminate();
     onClose();
@@ -48,7 +47,6 @@ const EndExam = ({ handleTerminate }: Props) => {
               <Button ref={cancelRef} onClick={onClose}>
                 No
               </Button>
-              {/* Modify the onClick handler of the "Yes" button */}
               <Button colorScheme="red" onClick={handleConfirmTerminate} ml={3}>
                 Yes
               </Button>

--- a/face-react/src/components/alerts/InProgress.tsx
+++ b/face-react/src/components/alerts/InProgress.tsx
@@ -1,7 +1,49 @@
-import React from "react";
+// cant use this until exam database is up
+import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogContent,
+  AlertDialogOverlay,
+  useDisclosure,
+  Button,
+} from "@chakra-ui/react";
+import { useRef } from "react";
 
-const InProgress = () => {
-  return <div>InProgress</div>;
+const EndExam = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const cancelRef = useRef(null);
+
+  return (
+    <>
+      <AlertDialog
+        motionPreset="scale"
+        isOpen={isOpen}
+        leastDestructiveRef={cancelRef}
+        onClose={onClose}
+      >
+        <AlertDialogOverlay>
+          <AlertDialogContent>
+            <AlertDialogHeader fontSize="lg" fontWeight="bold">
+              Error
+            </AlertDialogHeader>
+
+            <AlertDialogBody>
+              Exam is already in progress. Please contact your university for
+              support.
+            </AlertDialogBody>
+
+            <AlertDialogFooter>
+              <Button ref={cancelRef} onClick={onClose}>
+                Okay
+              </Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      </AlertDialog>
+    </>
+  );
 };
 
-export default InProgress;
+export default EndExam;

--- a/face-react/src/components/alerts/LogOut.tsx
+++ b/face-react/src/components/alerts/LogOut.tsx
@@ -1,7 +1,58 @@
-import React from "react";
+import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogContent,
+  AlertDialogOverlay,
+  useDisclosure,
+  Button,
+} from "@chakra-ui/react";
+import { useRef } from "react";
 
-const LogOut = () => {
-  return <div>LogOut</div>;
+interface Props {
+  handleLogout: () => void;
+}
+
+const EndExam = ({ handleLogout }: Props) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const cancelRef = useRef(null);
+
+  const handleConfirmLogout = () => {
+    handleLogout();
+    onClose();
+  };
+
+  return (
+    <>
+      <button onClick={onOpen}>Log Exam</button>
+      <AlertDialog
+        motionPreset="scale"
+        isOpen={isOpen}
+        leastDestructiveRef={cancelRef}
+        onClose={onClose}
+      >
+        <AlertDialogOverlay>
+          <AlertDialogContent>
+            <AlertDialogHeader fontSize="lg" fontWeight="bold">
+              Log Out
+            </AlertDialogHeader>
+
+            <AlertDialogBody>Are you sure you want to log out?</AlertDialogBody>
+
+            <AlertDialogFooter>
+              <Button ref={cancelRef} onClick={onClose}>
+                No
+              </Button>
+              <Button colorScheme="red" onClick={handleConfirmLogout} ml={3}>
+                Yes
+              </Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      </AlertDialog>
+    </>
+  );
 };
 
-export default LogOut;
+export default EndExam;

--- a/face-react/src/components/alerts/TerminateExam.tsx
+++ b/face-react/src/components/alerts/TerminateExam.tsx
@@ -1,7 +1,62 @@
-import React from "react";
+import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogContent,
+  AlertDialogOverlay,
+  useDisclosure,
+  Button,
+} from "@chakra-ui/react";
+import { useRef } from "react";
 
-const TerminateExam = () => {
-  return <div>TerminateExam</div>;
+interface Props {
+  handleTerminate: () => void;
+}
+
+const EndExam = ({ handleTerminate }: Props) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const cancelRef = useRef(null);
+
+  const handleConfirmTerminate = () => {
+    handleTerminate();
+    onClose();
+  };
+
+  return (
+    <>
+      <button onClick={onOpen}>Terminate Exam</button>
+      <AlertDialog
+        motionPreset="scale"
+        isOpen={isOpen}
+        leastDestructiveRef={cancelRef}
+        onClose={onClose}
+      >
+        <AlertDialogOverlay>
+          <AlertDialogContent>
+            <AlertDialogHeader fontSize="lg" fontWeight="bold">
+              Terminate Exam
+            </AlertDialogHeader>
+
+            <AlertDialogBody>
+              Are you sure you want to terminate this student's exam?
+              {/* We can include the actual persons name here when we set up the database */}
+            </AlertDialogBody>
+
+            <AlertDialogFooter>
+              <Button ref={cancelRef} onClick={onClose}>
+                No
+              </Button>
+              <Button colorScheme="red" onClick={handleConfirmTerminate} ml={3}>
+                {/* termination is logically the same as end exam */}
+                Yes
+              </Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      </AlertDialog>
+    </>
+  );
 };
 
-export default TerminateExam;
+export default EndExam;


### PR DESCRIPTION
Just updated the front end core: 
Made all the alert dialogues as separate components with the end exam alert dialog working with no styling.

The rest should all be fairly similar with their own respective logic for their requirements of application to the program, will do this later in the week.

Started the login logic which prevents a student from re-logging into the exam, thinking of using an event listener to nullify the back option in the browser if we all agree on it. 

Also a student now cannot access teacher pages due to their account type and teacher does not need access to student pages etc. If we like and have time, we can style the 404 not found page. 

Completed the flesh of the other alerts, exam termination won't be fired off until the exam database is live, same with exam in progress. 